### PR TITLE
When connection drop close all pullers

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -186,12 +186,10 @@ func (conn *Connection) closeAllPullers() {
 
 func (conn *Connection) dispatch(msg *Message) {
 	var wg sync.WaitGroup
-
 	wg.Add(4)
 	go conn.pushToChans(&wg, conn.center.getPullers(all), msg)
 	go conn.pushToChans(&wg, conn.center.getPullers(toKey(msg.Topic, "", "")), msg)
 	go conn.pushToChans(&wg, conn.center.getPullers(toKey(msg.Topic, msg.Event, "")), msg)
 	go conn.pushToChans(&wg, conn.center.getPullers(toKey("", "", msg.Ref)), msg)
-
 	wg.Wait()
 }

--- a/client/connection.go
+++ b/client/connection.go
@@ -115,7 +115,7 @@ func (conn *Connection) pullLoop() {
 			conn.msgs <- nil
 			fmt.Printf("%s\n", err)
 			close(conn.msgs)
-			conn.closePullers(conn.center.getPullers(all))
+			conn.closeAllPullers()
 			return
 		}
 		select {
@@ -169,6 +169,19 @@ func (conn *Connection) closePullers(pullers []*Puller) {
 	for _, puller := range pullers {
 		close(puller.ch)
 	}
+}
+
+func (conn *Connection) closeAllPullers() {
+
+	conn.center.RLock()
+	defer conn.center.RUnlock()
+
+	for _, pullers := range conn.center.regs {
+		for _, puller := range pullers {
+			close(puller.ch)
+		}
+	}
+
 }
 
 func (conn *Connection) dispatch(msg *Message) {


### PR DESCRIPTION
When connection to phoenix server drop all channels in pullers will be closed so when listening for events you now when connection is closed and you can try reconnecting